### PR TITLE
support knex 0.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ st = knex.postgis;
 knex.postgisDefineExtras(function(knex, formatter){
   return {
     utmzone: function(geom) {
-      return knex.raw('utmzone(?)', formatter.wrapWKT(geom));
+      return knex.raw('utmzone(?)', [formatter.wrapWKT(geom)]);
     }
   };
 });

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -4,19 +4,19 @@ module.exports = function(knex, formatter) {
   var postgis = {
 
     x: function(geom) {
-      return knex.raw('ST_X(?)', formatter.wrapWKT(geom));
+      return knex.raw('ST_X(?)', [formatter.wrapWKT(geom)]);
     },
 
     y: function(geom) {
-      return knex.raw('ST_Y(?)', formatter.wrapWKT(geom));
+      return knex.raw('ST_Y(?)', [formatter.wrapWKT(geom)]);
     },
 
     area: function(geom) {
-      return knex.raw('ST_area(?)', formatter.wrapWKT(geom));
+      return knex.raw('ST_area(?)', [formatter.wrapWKT(geom)]);
     },
 
     asText: function(col) {
-      var raw = knex.raw('ST_asText(?)', formatter.wrapWKT(col));
+      var raw = knex.raw('ST_asText(?)', [formatter.wrapWKT(col)]);
       if (typeof col === 'string') {
         raw.as(col);
       }
@@ -24,7 +24,7 @@ module.exports = function(knex, formatter) {
     },
 
     asEWKT: function(col) {
-      var raw = knex.raw('ST_asEWKT(?)', formatter.wrapWKT(col));
+      var raw = knex.raw('ST_asEWKT(?)', [formatter.wrapWKT(col)]);
       if (typeof col === 'string') {
         raw.as(col);
       }
@@ -32,7 +32,7 @@ module.exports = function(knex, formatter) {
     },
 
     centroid: function(geom) {
-      return knex.raw('ST_centroid(?)', formatter.wrapWKT(geom));
+      return knex.raw('ST_centroid(?)', [formatter.wrapWKT(geom)]);
     },
 
     intersection: function(geom1, geom2) {
@@ -59,7 +59,7 @@ module.exports = function(knex, formatter) {
       }
 
       if (typeof srid === 'undefined') {
-        return knex.raw('ST_geomFromText(?)', formatter.wrapWKT(geom));
+        return knex.raw('ST_geomFromText(?)', [formatter.wrapWKT(geom)]);
       } else {
         return knex.raw('ST_geomFromText(?, ?)', [formatter.wrapWKT(geom), srid]);
       }
@@ -82,7 +82,7 @@ module.exports = function(knex, formatter) {
     },
 
     asGeoJSON: function(col) {
-      var raw = knex.raw('ST_asGeoJSON(?)', formatter.wrapWKT(col));
+      var raw = knex.raw('ST_asGeoJSON(?)', [formatter.wrapWKT(col)]);
       if (typeof col === 'string') {
         raw.as(col);
       }
@@ -90,7 +90,7 @@ module.exports = function(knex, formatter) {
     },
 
     geomFromGeoJSON: function(geom) {
-      return knex.raw('ST_geomFromGeoJSON(?)', formatter.wrapGeoJSON(geom));
+      return knex.raw('ST_geomFromGeoJSON(?)', [formatter.wrapGeoJSON(geom)]);
     }
   };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ module.exports = function(knex) {
     if (typeof value === 'string' && value.match(wktRegex)) {
       return value;
     } else {
-      return knex.raw(this.wrap(value));
+      return knex.raw(this.wrap(value), []);
     }
   };
 
@@ -46,7 +46,7 @@ module.exports = function(knex) {
       geom = value;
     } else {
       if (typeof value === 'string' && value.match(/^[^\{\}]*$/)) {
-        return knex.raw(this.wrap(value));
+        return knex.raw(this.wrap(value), []);
       }
       try {
         geom = JSON.parse(value);
@@ -59,7 +59,7 @@ module.exports = function(knex) {
   };
 
   // attach postgis functions
-  formatter = new knex.client.Formatter();
+  formatter = new knex.client.Formatter(knex.client);
   knex.postgis = require('./functions')(knex, formatter);
 
   knex.postgisDefineExtras = function(fnBuilder) {


### PR DESCRIPTION
knex 0.8.x due to a bug, require the second argument of knew.raw be
always an array.