### PR TITLE
Fix recognition of multi* WKTs.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ var geojsonhint = require('geojsonhint');
 var wktRegex = new RegExp('^(srid=\\d+;)?(' + [
   'geometry(collection)?',
   'curvepolygon',
-  '((multi)?point|polygon|curve|surface|linestring)',
+  '((multi)?(point|polygon|curve|surface|linestring))',
   'triangle',
   'circularstring',
   'CompoundCurve',
@@ -47,7 +47,7 @@ function isString(s) {
 }
 
 function isWKT(value) {
-  return value.match(wktRegex);
+  return wktRegex.test(value);
 }
 
 exports.isBoolean = isBoolean;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chai": "^1.9.2",
     "compare-versions": "^2.0.2",
     "eslint": "^3.2.0",
-    "knex": "^0.7.3",
+    "knex": "^0.8.6",
     "mocha": "^1.21.5"
   },
   "scripts": {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -17,7 +17,6 @@ function testError(obj) {
   }).to.throw(Error);
 }
 
-
 describe('geoJSON validation', function() {
 
   it('filter invalid ', function() {
@@ -193,6 +192,64 @@ describe('isString validation', function() {
 
     it('for functions', function() {
       expect(utils.isString(function() {})).to.be.false;
+    });
+  });
+});
+
+describe('isWKT validation', function() {
+  describe('responds `true` for valid WKTs', function() {
+    it('for points', function() {
+      var wkt = 'POINT(6 10)';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+
+    it('for linestrings', function() {
+      var wkt = 'LINESTRING(3 4,10 50,20 25)';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+
+    it('for polygons', function() {
+      var wkt = 'POLYGON((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2))';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+
+    it('for multipoints', function() {
+      var wkt = 'MULTIPOINT(3.5 5.6, 4.8 10.5)';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+
+    it('for multilinestrings', function() {
+      var wkt = 'MULTILINESTRING((3 4,10 50,20 25),(-5 -8,-10 -8,-15 -4))';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+
+    it('for multipolygons', function() {
+      var wkt = 'MULTIPOLYGON(((1 1,5 1,5 5,1 5,1 1),(2 2, 3 2, 3 3, 2 3,2 2)),((3 3,6 2,6 4,3 3))';
+
+      expect(utils.isWKT(wkt)).to.be.true;
+    });
+  });
+
+  describe('responds `false` for invalid WKTs', function() {
+    it('for nothing', function() {
+      expect(utils.isWKT()).to.be.false;
+    });
+
+    it('for null', function() {
+      expect(utils.isWKT(null)).to.be.false;
+    });
+
+    it('for undefined', function() {
+      expect(utils.isWKT(undefined)).to.be.false;
+    });
+
+    it('for non-WKT strings', function() {
+      expect(utils.isWKT('geom')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
The regular expression used by the `isWKT` function is not recognizing `multi(polygon|curve|surface|linestring)` WKTs. 

This PR fixes the bug and adds a few tests to cover the isWKT function. 